### PR TITLE
Fix Homebrew shellenv configuration

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -14,6 +14,7 @@
     "linuxbrew",
     "markdownlint",
     "passwordless",
+    "shellcheck",
     "shellenv"
   ]
 }

--- a/variants/homebrew/Dockerfile
+++ b/variants/homebrew/Dockerfile
@@ -5,15 +5,5 @@
 
 FROM ghcr.io/bottle-garden/github-devcontainer/base:main
 
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-# hadolint ignore=SC2016
-RUN curl -fsSL \
-  https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh | \
-  /bin/bash && \
-  echo 'eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"' >> \
-  /etc/profile && \
-  eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)" && \
-  apt-get update && \
-  apt-get install -y --no-install-recommends build-essential=12.8ubuntu1.1 && \
-  rm -rf /var/lib/apt/lists/* && \
-  brew install gcc
+COPY build.sh /tmp/build.sh
+RUN /tmp/build.sh && rm /tmp/build.sh

--- a/variants/homebrew/build.sh
+++ b/variants/homebrew/build.sh
@@ -1,0 +1,23 @@
+#!/bin/sh -e
+
+BREW="https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh"
+
+BUILD_ESSENTIAL="build-essential=12.8ubuntu1.1"
+
+curl -fsSL "${BREW}" | /bin/bash
+
+cat > /tmp/shellenv <<EOF
+
+eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+EOF
+
+cat /tmp/shellenv >> /etc/bash.bashrc
+
+# shellcheck disable=SC1091
+. /tmp/shellenv
+
+apt-get update
+apt-get install -y --no-install-recommends "${BUILD_ESSENTIAL}"
+rm -rf /var/lib/apt/lists/*
+
+brew install gcc


### PR DESCRIPTION
Specifically:

- Previously, the `brew shellenv` command was added to `/etc/profile`, however, this doesn't work with `sudo` by default because `/etc/profile` is only read for login shells. The result is that `sudo` is unable to find `brew` on the `PATH`.

  To fix this, the `brew shellenv` has been appended to the `/etc/bash.bashrc` instead.

- Additionally, the build commands for this image have been moved to `build.sh`. This file is then copied to the container, executed, and then removed.

  Doing this allows me to format the shell commands in a more readable way.