### PR TITLE
Improve container setups

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -11,7 +11,8 @@ on:
 jobs:
   lint:
     name: 'Lint checks'
-    runs-on: ubuntu-latest
+    # Pin the GitHub version to match the VS Code version
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       # cspell:disable-next-line
@@ -33,7 +34,8 @@ jobs:
   changes:
     name: 'Detect changes'
     needs: lint
-    runs-on: ubuntu-latest
+    # Pin the GitHub version to match the VS Code version
+    runs-on: ubuntu-20.04
     outputs:
       variants: ${{ steps.filter.outputs.changes }}
     steps:
@@ -50,7 +52,8 @@ jobs:
     name: 'Build variant: ${{ matrix.variant }}'
     needs: changes
     if: needs.changes.outputs.variants != '[]'
-    runs-on: ubuntu-latest
+    # Pin the GitHub version to match the VS Code version
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: true
       max-parallel: 1

--- a/cspell.json
+++ b/cspell.json
@@ -12,8 +12,10 @@
     "ghcr",
     "hadolint",
     "linuxbrew",
+    "localedef",
     "markdownlint",
     "passwordless",
+    "shellcheck",
     "shellenv"
   ]
 }

--- a/variants/base/Dockerfile
+++ b/variants/base/Dockerfile
@@ -3,7 +3,14 @@
 
 # Last modified: 2021-09-25 23:10:29
 
-FROM mcr.microsoft.com/vscode/devcontainers/base:0-ubuntu
+# Available Ubuntu versions:
+#
+# - https://hub.docker.com/_/microsoft-vscode-devcontainers
+# - https://github.com/actions/virtual-environments
 
-# Create user for the GitHub-hosted runner
-RUN useradd --create-home runner
+# Pin the VS Code version to match the GitHub version
+FROM mcr.microsoft.com/vscode/devcontainers/base:ubuntu-21.04
+
+# Run the build
+COPY build.sh /tmp/build.sh
+RUN /tmp/build.sh && rm /tmp/build.sh

--- a/variants/base/build.sh
+++ b/variants/base/build.sh
@@ -1,0 +1,14 @@
+#!/bin/sh -e
+
+# Update packages
+apt-get update
+apt-get dist-upgrade -y
+
+# Clean up APT
+apt-get clean
+apt-get auto-remove
+rm -rf /var/lib/apt/lists/*
+
+# Create a user for the GitHub-hosted runner
+localedef -i en_US -f UTF-8 en_US.UTF-8
+useradd -m -s /bin/bash runner

--- a/variants/homebrew/Dockerfile
+++ b/variants/homebrew/Dockerfile
@@ -5,15 +5,6 @@
 
 FROM ghcr.io/bottle-garden/github-devcontainer/base:main
 
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-# hadolint ignore=SC2016
-RUN curl -fsSL \
-  https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh | \
-  /bin/bash && \
-  echo 'eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"' >> \
-  /etc/profile && \
-  eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)" && \
-  apt-get update && \
-  apt-get install -y --no-install-recommends build-essential=12.8ubuntu1.1 && \
-  rm -rf /var/lib/apt/lists/* && \
-  brew install gcc
+# Run the build
+COPY build.sh /tmp/build.sh
+RUN /tmp/build.sh && rm /tmp/build.sh

--- a/variants/homebrew/build.sh
+++ b/variants/homebrew/build.sh
@@ -1,0 +1,39 @@
+#!/bin/sh -e
+
+BREW="https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh"
+
+BUILD_ESSENTIAL="build-essential=12.8ubuntu1.1"
+
+# Install Homebrew
+curl -fsSL "${BREW}" | /bin/bash
+
+# Set up Homebrew `shellenv` snippet
+cat > /tmp/shellenv <<EOF
+
+eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+EOF
+
+# Copy the `shellenv` snippet to the system Bash configuration, so that `brew`
+# is on the `PATH` for every user
+cat /tmp/shellenv >> /etc/bash.bashrc
+
+# Source the `shellenv` snippet and then remove
+# shellcheck disable=SC1091
+. /tmp/shellenv
+rm /tmp/shellenv
+
+# Update packages
+apt-get update
+apt-get dist-upgrade -y
+
+# Install build tools
+apt-get install -y --no-install-recommends "${BUILD_ESSENTIAL}"
+brew install gcc
+
+# Clean up APT
+apt-get clean
+apt-get auto-remove
+rm -rf /var/lib/apt/lists/*
+
+# Clean up Homebrew
+brew cleanup -v -s --prune=all


### PR DESCRIPTION
Specifically:

- Pin the VS Code and Ubuntu versions so that they match each other.

- The build commands for this image have been moved to `build.sh`. This file is then copied to the container, executed, and then removed. Doing this allows me to format the shell commands in a more readable way.

- Both images now perform a `dist-upgrade`. Additionally, cleanup tasks have been expanded.

- Previously, the `brew shellenv` command was added to `/etc/profile`. However, bdyefault,  this doesn't work with `sudo` because `/etc/profile` is only read for login shells. The result is that `sudo` cannot find `brew` on the `PATH`.

  To fix this, the `brew shellenv` has been appended to the `/etc/bash.bashrc` instead.