### PR TITLE
Unpin `build-essential`

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,15 @@
 <!-- markdownlint-disable-next-line MD036 -->
 _Development containers for simultaneous use with VS Code and GitHub Actions_
 
+<!-- cspell:disable -->
+
 - [Containers](#containers)
   - [`github-devcontainer/base`](#github-devcontainerbase)
   - [`github-devcontainer/homebrew`](#github-devcontainerhomebrew)
+- [Notes](#notes)
+  - [Dependency versions](#dependency-versions)
+
+<!-- cspell:enable -->
 
 ## Containers
 
@@ -40,14 +46,32 @@ The [github-devcontainer/homebrew][homebrew] container is based on the
 [github-devcontainer/base][base] container and comes with a full
 [Homebrew][brew] installation.
 
+## Notes
+
+### Dependency versions
+
+The [Haskell Dockerfile Linter][hadolint] (`hadolint`) lint recommends
+([DL3008][DL3008]) that container dependencies should be pinned to a specific
+version. However, these development containers are designed to pull the latest
+version of each dependency.
+
+Because these containers are designed not for development environments, the
+builds do not have to produce consistent results. All that matters is that once
+published, each containers provides an identical environment for VS Code and
+GitHub Actions.
+
+<!-- Link references, sorted alphabetically ascending -->
+
 [actions]: https://docs.github.com/en/actions
 [base]: https://github.com/orgs/bottle-garden/packages/container/package/github-devcontainer%2Fbase
+[brew]: https://brew.sh/
 [container]: https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#jobsjob_idcontainer
 [devcontainer]: https://code.visualstudio.com/docs/remote/containers
+[DL3008]: https://github.com/hadolint/hadolint/wiki/DL3008
+[hadolint]: https://github.com/hadolint/hadolint
 [homebrew]: https://github.com/orgs/bottle-garden/packages/container/package/github-devcontainer%2Fhomebrew
 [job]: https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#jobsjob_id
 [runner]: https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners
 [steps]: https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#jobsjob_idsteps
 [ubuntu]: https://github.com/microsoft/vscode-dev-containers/tree/main/containers/ubuntu
 [vscode]: https://code.visualstudio.com/
-[brew]: https://brew.sh/

--- a/variants/base/Dockerfile
+++ b/variants/base/Dockerfile
@@ -1,7 +1,8 @@
 # Dockerfile configuration
 # https://docs.docker.com/engine/reference/builder/
 
-# Last modified: 2021-09-25 23:10:29
+# Update timestamp to force a rebuild
+# 1632674108503
 
 # Available Ubuntu versions:
 #

--- a/variants/homebrew/Dockerfile
+++ b/variants/homebrew/Dockerfile
@@ -1,7 +1,8 @@
 # Dockerfile configuration
 # https://docs.docker.com/engine/reference/builder/
 
-# Last modified: 2021-09-25 23:37:18
+# Update timestamp to force a rebuild
+# 1632674108503
 
 FROM ghcr.io/bottle-garden/github-devcontainer/base:main
 

--- a/variants/homebrew/build.sh
+++ b/variants/homebrew/build.sh
@@ -2,8 +2,6 @@
 
 BREW="https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh"
 
-BUILD_ESSENTIAL="build-essential=12.8ubuntu1.1"
-
 # Install Homebrew
 curl -fsSL "${BREW}" | /bin/bash
 
@@ -27,7 +25,7 @@ apt-get update
 apt-get dist-upgrade -y
 
 # Install build tools
-apt-get install -y --no-install-recommends "${BUILD_ESSENTIAL}"
+apt-get install -y --no-install-recommends build-essential
 brew install gcc
 
 # Clean up APT


### PR DESCRIPTION
The [Haskell Dockerfile Linter][hadolint] (`hadolint`) lint recommends ([DL3008][DL3008]) that container dependencies should be pinned to a specific version. However, these development containers are designed to pull the latest version of each dependency.

Because these containers are designed not for development environments, the builds do not have to produce consistent results. All that matters is that once published, each containers provides an identical environment for VS Code and GitHub Actions.

[DL3008]: https://github.com/hadolint/hadolint/wiki/DL3008
[hadolint]: https://github.com/hadolint/hadolint